### PR TITLE
docs: cancel v0.5.1 Draft release

### DIFF
--- a/docs/DECISIONS_LOG.md
+++ b/docs/DECISIONS_LOG.md
@@ -65,6 +65,12 @@ Evidence (gh api):
 Rationale:
 - Prevent direct pushes and risky merges; ensure CI gates are respected for all roles.
 
+## 2025-09-06
+- Decision: Release v0.5.1 Draft を破棄
+- Reason: 安定性未確保（CI成功率55%）、branch protection未設定、リリース体系不整合リスク解消のため。
+- Reference: v0.5.0-phase4.3-proof を安定版として維持。Phase 5で新しい安定版（例: v0.5.2）を再設計する。
+- Approved by: 統括PM
+
 
 
 


### PR DESCRIPTION
## Summary
- Record formal decision to cancel v0.5.1 Draft release
- Delete Draft releases from GitHub (completed separately)
- Maintain v0.5.0-phase4.3-proof as current stable baseline

## Decision Details
- **Reason**: Stability concerns (CI success rate 55%), branch protection gaps, release consistency risks
- **Action**: Cancel v0.5.1 Draft, continue with v0.5.0-phase4.3-proof as stable reference
- **Future Plan**: Redesign new stable release (e.g., v0.5.2) during Phase 5
- **Approved by**: 統括PM

## Changes
- Added 2025-09-06 decision entry to `docs/DECISIONS_LOG.md`
- No CHANGELOG updates required (draft was never released)

🤖 Generated with [Claude Code](https://claude.ai/code)