### PR TITLE
docs: adopt RFC-001 & record Stage A activation

### DIFF
--- a/docs/DECISIONS_LOG.md
+++ b/docs/DECISIONS_LOG.md
@@ -94,3 +94,8 @@ Rationale:
 
 
 
+## 2025-09-07
+- Decision: RFC-001 (MCP-in-CI) を採択。Stage A（静的検証）を有効化。
+- Reason: MCPプロファイルの安全性・一貫性をCIで担保するため。
+- Approved by: 統括PM
+

--- a/docs/HISTORY/INDEX.md
+++ b/docs/HISTORY/INDEX.md
@@ -37,3 +37,8 @@
 - **月次**: 古いエントリの統合・アーカイブ化
 
 詳細な運用方針は [AGGREGATION_POLICY.md](./AGGREGATION_POLICY.md) を参照してください。
+## 2025-09-07: RFC-001 採択とStage A導入
+- **要点**: RFC-001 (MCP-in-CI) 採択。Stage A（ci-mcp-validate）静的検証を導入。
+- **成果**: JSON Schema検証、allowlist境界チェック、セキュリティ制約適用
+- **根拠**: [PR #59](https://github.com/Driedsandwich/ucomm/pull/59), [PR #60](https://github.com/Driedsandwich/ucomm/pull/60), [RFC-001](docs/RFC/001-mcp-in-ci.md), [Issue #13](https://github.com/Driedsandwich/ucomm/issues/13)
+- **詳細**: [DECISIONS_LOG.md](../DECISIONS_LOG.md#2025-09-07)

--- a/docs/HISTORY/INDEX.md
+++ b/docs/HISTORY/INDEX.md
@@ -18,7 +18,7 @@
   - CLI bins PoC（Issue #12）：3OS対応JSON検証機能付きで完了
   - Branch Protection（Issue #54）：必須チェック適用、人依存排除
   - セキュリティ強化：CodeQL + Dependabot導入
-- **根拠**: [PR #55](https://github.com/Driedsandwich/ucomm/pull/55), [PR #56](https://github.com/Driedsandwich/ucomm/pull/56), [PR #57](https://github.com/Driedsandwich/ucomm/pull/57), [handoff-20250907-0111](../handoffs/handoff-20250907-0111-feat_cli-bins-poc-health.md)
+- **根拠**: [PR #55](https://github.com/Driedsandwich/ucomm/pull/55), [PR #56](https://github.com/Driedsandwich/ucomm/pull/56), [PR #57](https://github.com/Driedsandwich/ucomm/pull/57), [CLI PoC](../CI/CLI_BINS_POC.md)
 - **詳細**: [DECISIONS_LOG.md](../DECISIONS_LOG.md#2025-09-06)
 
 ---
@@ -40,5 +40,5 @@
 ## 2025-09-07: RFC-001 採択とStage A導入
 - **要点**: RFC-001 (MCP-in-CI) 採択。Stage A（ci-mcp-validate）静的検証を導入。
 - **成果**: JSON Schema検証、allowlist境界チェック、セキュリティ制約適用
-- **根拠**: [PR #59](https://github.com/Driedsandwich/ucomm/pull/59), [PR #60](https://github.com/Driedsandwich/ucomm/pull/60), [RFC-001](docs/RFC/001-mcp-in-ci.md), [Issue #13](https://github.com/Driedsandwich/ucomm/issues/13)
+- **根拠**: [PR #59](https://github.com/Driedsandwich/ucomm/pull/59), [PR #60](https://github.com/Driedsandwich/ucomm/pull/60), [RFC-001](../RFC/001-mcp-in-ci.md), [Issue #13](https://github.com/Driedsandwich/ucomm/issues/13)
 - **詳細**: [DECISIONS_LOG.md](../DECISIONS_LOG.md#2025-09-07)


### PR DESCRIPTION
Adds decisions + SSOT pointer. Relates to #13.

## RFC-001 Adoption Record

This PR documents the formal adoption of RFC-001 (MCP-in-CI) and records the activation of Stage A static validation in the SSOT.

### Changes

**DECISIONS_LOG.md** - Add 2025-09-07 decision record:
- ✅ RFC-001 (MCP-in-CI) formally adopted
- ✅ Stage A (static validation) activated via ci-mcp-validate workflow
- Rationale: Ensure MCP profile safety and consistency in CI pipeline

**HISTORY/INDEX.md** - Add SSOT reference:
- RFC-001 adoption and Stage A implementation summary  
- Cross-references to PR #59, #60, RFC document, and Issue #13
- Maintains audit trail for Phase 5 deliverables

### Implementation Status

- [x] RFC-001 document merged ([PR #59](https://github.com/Driedsandwich/ucomm/pull/59))
- [x] Stage A static validation merged ([PR #60](https://github.com/Driedsandwich/ucomm/pull/60))
- [x] MCP JSON Schema validation active
- [x] Security boundary enforcement (read-only, localhost, GET-only)
- [x] CI workflow integration complete

**Next Phase**: Stage B (ephemeral runtime testing) per RFC-001 roadmap.

Completes: #13 (Stage A implementation)  
References: [RFC-001](https://github.com/Driedsandwich/ucomm/blob/main/docs/RFC/001-mcp-in-ci.md)