### PR TITLE
fix: MCP schema compatibility with ajv-cli (draft-07)

### DIFF
--- a/schemas/mcp.schema.json
+++ b/schemas/mcp.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": ["version","transport","tools","policy","logging"],
   "properties": {


### PR DESCRIPTION
Fixes ci-mcp-validate workflow failure by updating JSON schema to draft-07 format.

## Issue
ajv-cli@5 does not support draft/2020-12 metaschema, causing validation failure:
```
error: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
```

## Fix
- Update `schemas/mcp.schema.json` to use draft-07 metaschema
- Maintains all validation constraints and properties
- Compatible with ajv-cli@5 used in CI workflow

## Validation
- Schema structure unchanged (version, transport, tools, policy, logging)
- Security constraints preserved (read-only, GET-only, localhost binding)
- Ready for ci-mcp-validate workflow success

Critical hotfix to enable MCP Stage A validation in CI.