### PR TITLE
test: verify ci-mcp-validate stability

### DIFF
--- a/profiles/mcp/default/mcp.json
+++ b/profiles/mcp/default/mcp.json
@@ -5,6 +5,6 @@
     "git":{"allow":["https://github.com/*/*"],"auth":{"provider":"github","tokenEnv":"GITHUB_TOKEN","required":false},"mode":"ro"},
     "fetch":{"allow":["https://raw.githubusercontent.com/*"],"methods":["GET"],"timeoutMs":8000,"maxBytes":5242880}
   },
-  "policy":{"secureModeEnv":"UCOMM_SECURE_MODE","onViolation":"fail","hotReload":false},
+  "policy":{"secureModeEnv":"UCOMM_SECURE_MODE","onViolation":"fail","hotReload":false,"testStability":true},
   "logging":{"dir":"logs/mcp","mask":["(?i)(api[_-]?key)\\s*[:=]\\s*\\S+"],"stdout":"server-stdout.log","stderr":"server-stderr.log"}
 }


### PR DESCRIPTION
Test PR to verify ci-mcp-validate workflow functions correctly after schema fix.

Minor change to profiles/mcp/default/mcp.json to trigger MCP validation workflow and confirm:
- ✅ Schema validation passes with draft-07 format
- ✅ Profile structure validation works  
- ✅ Security constraint checking functions

Will close this PR once stability is confirmed for branch protection update.