### PR TITLE
chore(codeowners): add lite/** owners (@0nyx-lab)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@ schemas/               @Driedsandwich
 profiles/mcp/          @Driedsandwich
 docs/RFC/              @Driedsandwich
 docs/**                @Driedsandwich @0nyx-lab
+lite/**                @Driedsandwich @0nyx-lab
 
 # Fallback: everything else
 *                      @Driedsandwich


### PR DESCRIPTION
目的: lite/** の変更を @0nyx-lab でも承認できるように追加。
DoD: チェック緑 & @0nyx-lab 承認待ち。