### PR TITLE
chore: enforce LF endings for lite shell scripts (.gitattributes)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,8 @@
 Makefile        text eol=lf
 .github/**      text eol=lf
 docs/**         text eol=lf
+lite/bin/*      text eol=lf
+lite/bin/roles/* text eol=lf
 
 # --- Windows-native: CRLF ---
 *.bat           text eol=crlf


### PR DESCRIPTION
WSLでの shebang 実行時に発生する CRLF 由来の 'bash\r' を恒久対策。*.sh と lite/bin/** を LF に統一。