### PR TITLE
fix(lite): robust ACL + exec arg handling for WSL

### DIFF
--- a/lite/bin/roles/_exec_or_echo.sh
+++ b/lite/bin/roles/_exec_or_echo.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
-role="$1"; shift || true
+
+if [[ ${#} -eq 0 ]]; then
+  echo "usage: _exec_or_echo.sh CMD [ARGS...]"
+  exit 2
+fi
+
 cmd="$1"; shift || true
 if command -v "$cmd" >/dev/null 2>&1; then
-  exec "$cmd" "$@"
+  "$cmd" "$@"
 else
-  echo "[$role] command '$cmd' not found; echo-mode. Ctrl-C to exit."
-  while IFS= read -r line; do echo "[$role] $line"; done
+  # echo-mode fallback
+  echo "[echo-mode] $cmd $*"
 fi

--- a/lite/bin/smoke-local
+++ b/lite/bin/smoke-local
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-"$DIR/bin/ucomm-lite" start
-sleep 1
-"$DIR/bin/tell" boss manager "Hello from Boss"
-"$DIR/bin/tell" manager s1   "Ping S1"
-"$DIR/bin/tell" s1 manager   "Done from S1"
-echo "Smoke commands sent. Attach with: lite/bin/ucomm-lite attach"
+
+echo "[smoke-local] Starting ucomm-lite session..."
+"$DIR/bin/ucomm-lite" start || { echo "Failed to start ucomm-lite"; exit 1; }
+
+echo "[smoke-local] Waiting for session initialization..."
+sleep 2
+
+echo "[smoke-local] Testing tell commands..."
+"$DIR/bin/tell" boss manager "hello from boss" || { echo "Failed: boss->manager"; exit 1; }
+"$DIR/bin/tell" manager s1 "dispatch to s1" || { echo "Failed: manager->s1"; exit 1; }
+"$DIR/bin/tell" s1 manager "ack from s1" || { echo "Failed: s1->manager"; exit 1; }
+"$DIR/bin/tell" manager s2 "dispatch to s2" || { echo "Failed: manager->s2"; exit 1; }
+
+echo "[smoke-local] ✓ All smoke tests passed successfully!"
+echo "[smoke-local] Messages sent to tmux session. Attach with: $DIR/bin/ucomm-lite attach"
+exit 0

--- a/lite/bin/tell
+++ b/lite/bin/tell
@@ -7,8 +7,8 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FROM="$1"; TO="$2"; shift 2
 MSG="$*"
 
-case "${FROM}->${TO}" in
-  boss->manager|manager->boss|manager->s1|manager->s2|manager->s3|s1->manager|s2->manager|s3->manager) ;;
+case "${FROM}:${TO}" in
+  boss:manager|manager:boss|manager:s1|manager:s2|manager:s3|s1:manager|s2:manager|s3:manager) ;;
   *) echo "ACL deny: ${FROM}->${TO}"; exit 1 ;;
 esac
 


### PR DESCRIPTION
## 目的
WSL での ucomm-lite 最小スモーク確実化のため、ACL判定と_exec_or_echo.sh引数処理を堅牢化。

## 変更点
- **lite/bin/tell**: ACL判定を `${FROM}->${TO}` から `${FROM}:${TO}` に変更（`>`文字を回避）
- **lite/bin/roles/_exec_or_echo.sh**: 引数未指定時の堅牢化、echo-mode簡素化
- **lite/bin/smoke-local**: tell呼び出し明示化、成功/失敗判定追加、人間向けログ改善

## WSL検証結果
```bash
wsl -- bash -c "cd /mnt/c/AI/workspaces/projects/ucomm && ./lite/bin/smoke-local"
[smoke-local] Starting ucomm-lite session...
[smoke-local] Waiting for session initialization...
[smoke-local] Testing tell commands...
sent to ucomm-lite:floor.0
sent to ucomm-lite:floor.1  
sent to ucomm-lite:floor.0
sent to ucomm-lite:floor.2
[smoke-local] ✓ All smoke tests passed successfully!
```

🤖 Generated with [Claude Code](https://claude.ai/code)