### PR TITLE
fix(lite): use printf for clean tmux pane output

### DIFF
--- a/lite/bin/smoke-local
+++ b/lite/bin/smoke-local
@@ -15,5 +15,5 @@ echo "[smoke-local] Testing tell commands..."
 "$DIR/bin/tell" manager s2 "dispatch to s2" || { echo "Failed: manager->s2"; exit 1; }
 
 echo "[smoke-local] ✓ All smoke tests passed successfully!"
-echo "[smoke-local] Messages sent to tmux session. Attach with: $DIR/bin/ucomm-lite attach"
+echo "[smoke-local] Messages sent via printf to tmux session (clean output). Attach with: $DIR/bin/ucomm-lite attach"
 exit 0

--- a/lite/bin/tell
+++ b/lite/bin/tell
@@ -23,5 +23,5 @@ case "$TO" in
 esac
 
 tmux has-session -t "$UCOMM_SESSION" >/dev/null 2>&1 || { echo "no session '$UCOMM_SESSION'"; exit 4; }
-tmux send-keys -t "$pane" "[${FROM}->${TO}] ${MSG}" C-m
+tmux send-keys -t "$pane" "printf '%s\n' '[${FROM}->${TO}] ${MSG}'" C-m
 echo "sent to $pane"


### PR DESCRIPTION
## 目的
tmux pane への生文字列送信で稀に発生する "command not found" ノイズを根絶し、常に純粋な表示出力を実現。

## 変更点
- **lite/bin/tell**: `tmux send-keys` で生文字列の代わりに `printf '%s\n' '[...]'` コマンドを送信
- **lite/bin/smoke-local**: ログメッセージを printf 方式対応に微調整

## 技術詳細
従来: `tmux send-keys -t "$pane" "[${FROM}->${TO}] ${MSG}" C-m`
新方式: `tmux send-keys -t "$pane" "printf '%s\n' '[${FROM}->${TO}] ${MSG}'" C-m`

これにより、メッセージ内容がコマンドと誤解釈されることなく、常にログとして表示される。

## WSL検証結果
```bash
[smoke-local] ✓ All smoke tests passed successfully!
[smoke-local] Messages sent via printf to tmux session (clean output).

# Pane内出力例:
[manager->s1] dispatch to s1  # クリーンな表示、コマンド誤解釈なし
```

既存のACL・エラーコード・機能は完全に維持。

🤖 Generated with [Claude Code](https://claude.ai/code)