### PR TITLE
feat(lite): add per-pane web login flow with *_LOGIN_CMD and *_TEST_CMD

### DIFF
--- a/lite/.env.example
+++ b/lite/.env.example
@@ -1,6 +1,9 @@
 # ucomm-lite ENV (independent from main)
 UCOMM_SESSION="ucomm-lite"  # tmux session name
 
+# Login Mode: "web" (browser auth), "api-key" (token only), "echo" (no auth)
+LOGIN_MODE="web"
+
 # Role CLI Commands
 # Default: empty (echo-mode fallback displays input as-is)
 # Set to actual CLI command to execute real AI interactions
@@ -10,22 +13,49 @@ S1_CMD=""
 S2_CMD=""
 S3_CMD=""
 
+# Login Commands (for initial web authentication)
+# Default: empty (no login required)
+BOSS_LOGIN_CMD=""
+MANAGER_LOGIN_CMD=""
+S1_LOGIN_CMD=""
+S2_LOGIN_CMD=""
+S3_LOGIN_CMD=""
+
+# Test Commands (to verify authentication status)
+# Default: empty (no test performed)
+BOSS_TEST_CMD=""
+MANAGER_TEST_CMD=""
+S1_TEST_CMD=""
+S2_TEST_CMD=""
+S3_TEST_CMD=""
+
 # Example configurations by OS/CLI:
 # 
 # Gemini CLI:
 #   BOSS_CMD="gemini generate"
-#   MANAGER_CMD="gemini generate"
+#   BOSS_LOGIN_CMD="gemini auth login"
+#   BOSS_TEST_CMD="gemini auth whoami"
 #
 # Claude CLI (official):
 #   S1_CMD="claude"
-#   S2_CMD="claude"
+#   S1_LOGIN_CMD="claude auth login"
+#   S1_TEST_CMD="claude auth whoami"
 #
 # OpenAI CLI:
-#   S3_CMD="openai chat completions create --model gpt-3.5-turbo --messages"
+#   S2_CMD="openai chat completions create --model gpt-3.5-turbo --messages"
+#   S2_LOGIN_CMD="openai auth login"
+#   S2_TEST_CMD="openai auth"
 #
 # Mixed setup example:
+#   LOGIN_MODE="web"                 # Enable web login flow
 #   BOSS_CMD="gemini generate"       # Strategic planning
+#   BOSS_LOGIN_CMD="gemini auth login"
+#   BOSS_TEST_CMD="gemini auth whoami"
 #   MANAGER_CMD="claude"             # Task coordination  
+#   MANAGER_LOGIN_CMD="claude auth login"
+#   MANAGER_TEST_CMD="claude auth whoami"
 #   S1_CMD="claude"                  # Implementation
-#   S2_CMD="openai chat completions create --model gpt-4 --messages"  # Review
+#   S1_LOGIN_CMD="claude auth login"
+#   S1_TEST_CMD="claude auth whoami"
+#   S2_CMD=""                        # Keep as echo-mode
 #   S3_CMD=""                        # Keep as echo-mode

--- a/lite/bin/login-clis
+++ b/lite/bin/login-clis
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$DIR/_common.sh"
+
+usage() {
+    echo "usage: login-clis role <ROLE>"
+    echo "  ROLE: boss|manager|s1|s2|s3"
+    echo
+    echo "Handles CLI authentication for the specified role:"
+    echo "- web mode: attempts login if test fails"
+    echo "- api-key mode: skips (assumes manual token setup)"
+    echo "- echo mode: skips (no auth needed)"
+    exit 2
+}
+
+(( $# >= 2 )) || usage
+[[ "$1" == "role" ]] || usage
+ROLE="$2"
+
+# Validate role
+case "$ROLE" in
+    boss|manager|s1|s2|s3) ;;
+    *) echo "Error: Invalid role '$ROLE'"; usage ;;
+esac
+
+# Get LOGIN_MODE (default: web)
+LOGIN_MODE="${LOGIN_MODE:-web}"
+
+echo "[login-clis] Role: $ROLE, Mode: $LOGIN_MODE"
+
+case "$LOGIN_MODE" in
+    "echo")
+        echo "[login-clis] Echo mode - no authentication needed"
+        exit 0
+        ;;
+    "api-key")
+        echo "[login-clis] API-key mode - assuming manual token setup"
+        exit 0
+        ;;
+    "web")
+        # Continue to web login flow
+        ;;
+    *)
+        echo "[login-clis] Warning: Unknown LOGIN_MODE '$LOGIN_MODE', defaulting to web"
+        ;;
+esac
+
+# Get role-specific commands
+case "$ROLE" in
+    boss)
+        LOGIN_CMD="${BOSS_LOGIN_CMD:-}"
+        TEST_CMD="${BOSS_TEST_CMD:-}"
+        ;;
+    manager)
+        LOGIN_CMD="${MANAGER_LOGIN_CMD:-}"
+        TEST_CMD="${MANAGER_TEST_CMD:-}"
+        ;;
+    s1)
+        LOGIN_CMD="${S1_LOGIN_CMD:-}"
+        TEST_CMD="${S1_TEST_CMD:-}"
+        ;;
+    s2)
+        LOGIN_CMD="${S2_LOGIN_CMD:-}"
+        TEST_CMD="${S2_TEST_CMD:-}"
+        ;;
+    s3)
+        LOGIN_CMD="${S3_LOGIN_CMD:-}"
+        TEST_CMD="${S3_TEST_CMD:-}"
+        ;;
+esac
+
+# If no login command specified, skip
+if [[ -z "$LOGIN_CMD" ]]; then
+    echo "[login-clis] No login command specified for $ROLE - skipping authentication"
+    exit 0
+fi
+
+# Test current authentication status
+if [[ -n "$TEST_CMD" ]]; then
+    echo "[login-clis] Testing authentication status..."
+    if $TEST_CMD >/dev/null 2>&1; then
+        echo "[login-clis] Already authenticated for $ROLE"
+        exit 0
+    else
+        echo "[login-clis] Authentication required for $ROLE"
+    fi
+else
+    echo "[login-clis] No test command - proceeding with login"
+fi
+
+# Perform web login
+echo "[login-clis] Starting web authentication for $ROLE..."
+echo "[login-clis] Command: $LOGIN_CMD"
+echo "[login-clis] Follow the prompts in your browser"
+echo
+
+if $LOGIN_CMD; then
+    echo
+    echo "[login-clis] ✓ Authentication successful for $ROLE"
+    
+    # Verify with test command if available
+    if [[ -n "$TEST_CMD" ]] && $TEST_CMD >/dev/null 2>&1; then
+        echo "[login-clis] ✓ Authentication verified"
+    fi
+else
+    echo
+    echo "[login-clis] ✗ Authentication failed for $ROLE"
+    echo "[login-clis] You can:"
+    echo "  1. Re-run: $LOGIN_CMD"
+    echo "  2. Set LOGIN_MODE=echo to skip authentication"
+    echo "  3. Set LOGIN_MODE=api-key for manual token setup"
+    exit 1
+fi

--- a/lite/bin/ucomm-lite
+++ b/lite/bin/ucomm-lite
@@ -8,21 +8,21 @@ start() {
     echo "session '$UCOMM_SESSION' already exists"; return 0
   fi
   tmux new-session -d -s "$UCOMM_SESSION" -n boss
-  tmux send-keys -t "$UCOMM_SESSION":boss.0 "bash -lc '$DIR/roles/boss.sh'" C-m
+  tmux send-keys -t "$UCOMM_SESSION":boss.0 "bash -lc '$DIR/login-clis role boss && $DIR/roles/boss.sh'" C-m
   tmux select-pane -t "$UCOMM_SESSION":boss.0 -T "boss"
 
   tmux new-window -t "$UCOMM_SESSION" -n floor
-  tmux send-keys -t "$UCOMM_SESSION":floor.0 "bash -lc '$DIR/roles/manager.sh'" C-m
+  tmux send-keys -t "$UCOMM_SESSION":floor.0 "bash -lc '$DIR/login-clis role manager && $DIR/roles/manager.sh'" C-m
   tmux select-pane -t "$UCOMM_SESSION":floor.0 -T "manager"
   tmux split-window -t "$UCOMM_SESSION":floor -h
-  tmux send-keys -t "$UCOMM_SESSION":floor.1 "bash -lc '$DIR/roles/s1.sh'" C-m
+  tmux send-keys -t "$UCOMM_SESSION":floor.1 "bash -lc '$DIR/login-clis role s1 && $DIR/roles/s1.sh'" C-m
   tmux select-pane -t "$UCOMM_SESSION":floor.1 -T "s1"
   tmux split-window -t "$UCOMM_SESSION":floor -v
-  tmux send-keys -t "$UCOMM_SESSION":floor.2 "bash -lc '$DIR/roles/s2.sh'" C-m
+  tmux send-keys -t "$UCOMM_SESSION":floor.2 "bash -lc '$DIR/login-clis role s2 && $DIR/roles/s2.sh'" C-m
   tmux select-pane -t "$UCOMM_SESSION":floor.2 -T "s2"
   tmux select-pane -t "$UCOMM_SESSION":floor.1
   tmux split-window -t "$UCOMM_SESSION":floor -v
-  tmux send-keys -t "$UCOMM_SESSION":floor.3 "bash -lc '$DIR/roles/s3.sh'" C-m
+  tmux send-keys -t "$UCOMM_SESSION":floor.3 "bash -lc '$DIR/login-clis role s3 && $DIR/roles/s3.sh'" C-m
   tmux select-pane -t "$UCOMM_SESSION":floor.3 -T "s3"
 
   tmux select-window -t "$UCOMM_SESSION":boss


### PR DESCRIPTION
## 目的
ucomm-lite に「初回は各ペインでWebログイン→以後は自動」の導線を追加し、AI CLI認証の自動化を実現。

## 実装内容

### 1. lite/.env.example 拡張（+30行）
- `LOGIN_MODE` 追加: "web"（ブラウザ認証）| "api-key"（トークンのみ）| "echo"（認証なし）
- 各ロール用 `*_LOGIN_CMD` / `*_TEST_CMD` 環境変数追加
- CLI別設定例（Gemini/Claude/OpenAI）をコメントで詳述

### 2. lite/bin/login-clis 新規作成（115行）
- ロール別認証状態の確認と初回ログイン処理
- LOGIN_MODE による動作切り替え
- TEST_CMD で既存認証確認、LOGIN_CMD でWebログイン実行
- 詳細なエラーハンドリングと利用者ガイダンス

### 3. lite/bin/ucomm-lite 修正
- 各ペイン初期化時に `$DIR/login-clis role <role> && ` を前置
- 認証完了後に従来のロールスクリプト実行
- 既存機能への影響なし

## 利用フロー

### 初回起動時
```bash
lite/bin/ucomm-lite start
# 各ペインで必要に応じてブラウザ認証プロンプト表示
# デバイスコード or OAuth認証フローが展開
# 認証完了後、ロール起動
```

### 2回目以降
```bash
lite/bin/ucomm-lite start
# TEST_CMD で認証状態確認
# 既に認証済みの場合はログインスキップ
# 即座にロール起動
```

## 設定例
```bash
LOGIN_MODE="web"
BOSS_LOGIN_CMD="gemini auth login"
BOSS_TEST_CMD="gemini auth whoami"
MANAGER_LOGIN_CMD="claude auth login"
MANAGER_TEST_CMD="claude auth whoami"
```

## 互換性
- エコーモード（LOGIN_MODE="echo"）では認証スキップ
- 既存のCIテスト・smoke-localは通常通り動作
- 段階的導入可能（一部ロールのみ認証有効化）

## WSL検証結果
```bash
[smoke-local] ✓ All smoke tests passed successfully!
# セッション正常起動確認、回帰テスト通過
```

🤖 Generated with [Claude Code](https://claude.ai/code)