### PR TITLE
feat(lite): enhance detect-clis with auth detection & add login-clis status

### DIFF
--- a/lite/bin/detect-clis
+++ b/lite/bin/detect-clis
@@ -7,12 +7,65 @@ echo
 
 found=()
 samples=()
+login_samples=()
+
+# Function to detect auth commands from help output
+detect_auth_commands() {
+    local cmd="$1"
+    local login_cmd=""
+    local test_cmd=""
+    
+    # Try to get help output
+    local help_output=""
+    if help_output=$($cmd --help 2>/dev/null); then
+        :  # help succeeded
+    elif help_output=$($cmd help 2>/dev/null); then
+        :  # help succeeded
+    else
+        echo "# please set manually (no help available)"
+        return
+    fi
+    
+    # Look for login/auth commands
+    if echo "$help_output" | grep -qi "auth.*login"; then
+        login_cmd="$cmd auth login"
+    elif echo "$help_output" | grep -qi "\blogin\b"; then
+        login_cmd="$cmd login"
+    fi
+    
+    # Look for test/status commands  
+    if echo "$help_output" | grep -qi "auth.*whoami"; then
+        test_cmd="$cmd auth whoami"
+    elif echo "$help_output" | grep -qi "auth.*status"; then
+        test_cmd="$cmd auth status"
+    elif echo "$help_output" | grep -qi "\bwhoami\b"; then
+        test_cmd="$cmd whoami"
+    elif echo "$help_output" | grep -qi "\bauth\b" && echo "$help_output" | grep -qi "\bstatus\b"; then
+        test_cmd="$cmd auth"
+    fi
+    
+    # Output suggestions or manual setup
+    if [[ -n "$login_cmd" && -n "$test_cmd" ]]; then
+        echo "ROLE_LOGIN_CMD=\"$login_cmd\""
+        echo "ROLE_TEST_CMD=\"$test_cmd\""
+    elif [[ -n "$login_cmd" ]]; then
+        echo "ROLE_LOGIN_CMD=\"$login_cmd\""
+        echo "ROLE_TEST_CMD=\"# please set manually\""
+    elif [[ -n "$test_cmd" ]]; then
+        echo "ROLE_LOGIN_CMD=\"# please set manually\""
+        echo "ROLE_TEST_CMD=\"$test_cmd\""
+    else
+        echo "# please set manually (no auth commands detected)"
+    fi
+}
 
 # Check for Gemini CLI
 if command -v gemini >/dev/null 2>&1; then
     found+=("gemini")
     samples+=("BOSS_CMD=\"gemini generate\"")
     samples+=("MANAGER_CMD=\"gemini generate\"")
+    login_samples+=("# Gemini CLI:")
+    login_samples+=("$(detect_auth_commands gemini | sed 's/ROLE/BOSS/g')")
     echo "✓ Found: gemini (Google Gemini CLI)"
     echo "  Test command: gemini --version"
     gemini --version 2>/dev/null || echo "  (version check failed, but command exists)"
@@ -24,6 +77,8 @@ if command -v claude >/dev/null 2>&1; then
     found+=("claude")
     samples+=("S1_CMD=\"claude\"")
     samples+=("S2_CMD=\"claude\"")
+    login_samples+=("# Claude CLI:")
+    login_samples+=("$(detect_auth_commands claude | sed 's/ROLE/S1/g')")
     echo "✓ Found: claude (Anthropic Claude CLI)"
     echo "  Test command: claude --version"
     claude --version 2>/dev/null || echo "  (version check failed, but command exists)"
@@ -34,6 +89,8 @@ fi
 if command -v openai >/dev/null 2>&1; then
     found+=("openai")
     samples+=("S3_CMD=\"openai chat completions create --model gpt-3.5-turbo --messages\"")
+    login_samples+=("# OpenAI CLI:")
+    login_samples+=("$(detect_auth_commands openai | sed 's/ROLE/S3/g')")
     echo "✓ Found: openai (OpenAI CLI)"
     echo "  Test command: openai --version"
     openai --version 2>/dev/null || echo "  (version check failed, but command exists)"
@@ -45,6 +102,8 @@ for cmd in aichat ollama; do
     if command -v "$cmd" >/dev/null 2>&1; then
         found+=("$cmd")
         samples+=("# $cmd found - add manual configuration")
+        login_samples+=("# $cmd CLI:")
+        login_samples+=("$(detect_auth_commands $cmd | sed 's/ROLE/S2/g')")
         echo "✓ Found: $cmd"
         echo "  (manual configuration required)"
         echo
@@ -72,6 +131,20 @@ else
     echo
     echo "Note: Default empty values use echo-mode fallback."
     echo "Uncomment and modify as needed for your setup."
+    
+    # Add login command suggestions if any were detected
+    if [ ${#login_samples[@]} -gt 0 ]; then
+        echo
+        echo "=== Suggested Web Login Mode Lines ==="
+        echo "Copy these lines to your lite/.env file for web authentication:"
+        echo
+        echo "LOGIN_MODE=\"web\""
+        for login_sample in "${login_samples[@]}"; do
+            echo "$login_sample"
+        done
+        echo
+        echo "Note: Adjust ROLE names (BOSS/MANAGER/S1/S2/S3) as needed for your setup."
+    fi
 fi
 
 echo

--- a/lite/bin/login-clis
+++ b/lite/bin/login-clis
@@ -5,27 +5,79 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$DIR/_common.sh"
 
 usage() {
-    echo "usage: login-clis role <ROLE>"
-    echo "  ROLE: boss|manager|s1|s2|s3"
+    echo "usage: login-clis <COMMAND> [ARGS...]"
     echo
-    echo "Handles CLI authentication for the specified role:"
+    echo "Commands:"
+    echo "  role <ROLE>   Handle CLI authentication for specified role"
+    echo "                ROLE: boss|manager|s1|s2|s3"
+    echo "  status        Show authentication status for all roles"
+    echo
+    echo "Authentication modes:"
     echo "- web mode: attempts login if test fails"
     echo "- api-key mode: skips (assumes manual token setup)"
     echo "- echo mode: skips (no auth needed)"
     exit 2
 }
 
-(( $# >= 2 )) || usage
-[[ "$1" == "role" ]] || usage
-ROLE="$2"
+(( $# >= 1 )) || usage
+COMMAND="$1"
+shift
 
-# Validate role
-case "$ROLE" in
-    boss|manager|s1|s2|s3) ;;
-    *) echo "Error: Invalid role '$ROLE'"; usage ;;
+case "$COMMAND" in
+    "role")
+        (( $# >= 1 )) || usage
+        ROLE="$1"
+        # Validate role
+        case "$ROLE" in
+            boss|manager|s1|s2|s3) ;;
+            *) echo "Error: Invalid role '$ROLE'"; usage ;;
+        esac
+        ;;
+    "status")
+        # Status command - will be handled below
+        ;;
+    *)
+        echo "Error: Unknown command '$COMMAND'"
+        usage
+        ;;
 esac
 
-# Get LOGIN_MODE (default: web)
+# Handle status command
+if [[ "$COMMAND" == "status" ]]; then
+    echo "=== Authentication Status ==="
+    LOGIN_MODE="${LOGIN_MODE:-web}"
+    echo "Mode: $LOGIN_MODE"
+    echo
+    
+    for role in boss manager s1 s2 s3; do
+        # Get role-specific TEST_CMD
+        case "$role" in
+            boss) TEST_CMD="${BOSS_TEST_CMD:-}" ;;
+            manager) TEST_CMD="${MANAGER_TEST_CMD:-}" ;;
+            s1) TEST_CMD="${S1_TEST_CMD:-}" ;;
+            s2) TEST_CMD="${S2_TEST_CMD:-}" ;;
+            s3) TEST_CMD="${S3_TEST_CMD:-}" ;;
+        esac
+        
+        printf "%-8s: " "$role"
+        
+        if [[ -z "$TEST_CMD" ]]; then
+            echo "SKIP (no TEST_CMD)"
+        else
+            if output=$($TEST_CMD 2>&1); then
+                echo "OK - $TEST_CMD"
+            else
+                exit_code=$?
+                error_line=$(echo "$output" | head -n1)
+                echo "NG (exit $exit_code) - $TEST_CMD"
+                [[ -n "$error_line" ]] && echo "         Error: $error_line"
+            fi
+        fi
+    done
+    exit 0
+fi
+
+# Handle role command
 LOGIN_MODE="${LOGIN_MODE:-web}"
 
 echo "[login-clis] Role: $ROLE, Mode: $LOGIN_MODE"


### PR DESCRIPTION
## 目的
detect-clis の認証コマンド自動推測機能と login-clis の状態確認機能を追加し、Web認証設定の利便性を向上。

## A. detect-clis 強化（+60行）

### 機能拡張
- `detect_auth_commands()` 関数追加：CLI help出力から認証コマンドを推測
- 正規表現パターンマッチング：`auth.*login`, `whoami`, `status` 等を検出
- **非ハードコード**アプローチ：特定CLI名に依存せず help 出力から動的推測
- Web認証設定サンプル行の自動生成

### 出力例
```bash
=== Suggested Web Login Mode Lines ===
LOGIN_MODE="web"
# Gemini CLI:
BOSS_LOGIN_CMD="gemini auth login"
BOSS_TEST_CMD="gemini auth whoami"
# Claude CLI:  
S1_LOGIN_CMD="claude auth login"
S1_TEST_CMD="claude auth whoami"
```

### 推測ロジック
1. `cmd --help` または `cmd help` 実行
2. help出力から以下パターン検索：
   - LOGIN_CMD: `auth.*login`, `\blogin\b`
   - TEST_CMD: `auth.*whoami`, `auth.*status`, `\bwhoami\b`
3. 検出失敗時は `# please set manually` コメント出力

## B. login-clis status サブコマンド（+30行）

### 新機能
- `lite/bin/login-clis status` コマンド追加
- 全ロール（boss|manager|s1|s2|s3）の認証状態を一括確認
- OK/NG判定とエラー詳細表示

### 出力例
```bash
=== Authentication Status ===
Mode: web

boss    : SKIP (no TEST_CMD)
manager : OK - claude auth whoami
s1      : NG (exit 1) - gemini auth whoami
         Error: Authentication required
s2      : SKIP (no TEST_CMD)
```

### 仕様
- TEST_CMD 未設定時は `SKIP (no TEST_CMD)` 表示
- 成功時は `OK - <command>` 表示  
- 失敗時は `NG (exit <code>) - <command>` + エラー1行目表示
- 外部副作用なし、既存機能への影響なし

## 互換性・テスト
- 既存機能完全保持
- WSL smoke-local 通過確認済み
- ハードコード依存なし（将来のCLI追加に対応）

## 利用フロー改善
1. `lite/bin/detect-clis` → 認証設定サンプル自動生成
2. サンプルを `.env` にコピー
3. `lite/bin/login-clis status` → 認証状態確認
4. `lite/bin/ucomm-lite start` → 必要に応じて初回Web認証

🤖 Generated with [Claude Code](https://claude.ai/code)